### PR TITLE
allowing relative relative roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The DCML standard for harmonic annotations consists in a set of [annotation guid
 #### v2.1.0
 
 * Global keys (note names) and local keys (Roman numerals) are now parsed in two different groups. This solves the problem that previously, all pieces were assumed to start with localkey `I` or `i`. Now it is possible to have the global key *and* a change of local key within the first label, e.g. `Ab.vi.i` for a piece in Ab major that begins with an introduction in the relative key.
-* Previously accepted for no apparent reason, leading dots are not allowed for `relativeroot` anymore. For example, this would have been legal before, although never used: `V/.bIII`. The correct version is `V/bIII`.
-* Relative roots of unbouded levels are allowed now, as in `V7/V/V`. The feature `relativeroot` would be extracted as `V/V` in this case, i.e. without the initial slash.
+* Leading periods `.` are not allowed for `relativeroot` anymore. For example, the following would have been legal before, although never used: `V/.bIII`. The correct version is `V/bIII`.
+* Relative roots of unbounded levels are allowed now, as in `V7/V/V`. The feature `relativeroot` would be extracted as `V/V` in this case, i.e. without the initial slash.
 
 #### v2.0.0
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ The DCML standard for harmonic annotations consists in a set of [annotation guid
 
 ### Release Notes
 
+#### v2.1.0
+
+* Previously accepted for no apparent reason, leading dots are not allowed for `relativeroot` anymore. For example, this would have been legal before, although never used: `V/.bIII`. The correct version is `V/bIII`.
+* Relative roots of unbouded levels are allowed now, as in `V7/V/V`. The feature `relativeroot` would be extracted as `V/V` in this case, i.e. without the initial slash.
+
 #### v2.0.0
 
 * This version does not allow `9` as `figbass` feature anymore. This means that a label such as `V9` will throw an error. Instead, this chord needs to be written either as `V7(9)` or `V7(+9)`, depending on the context.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The DCML standard for harmonic annotations consists in a set of [annotation guid
 
 #### v2.1.0
 
+* Global keys (note names) and local keys (Roman numerals) are now parsed in two different groups. This solves the problem that previously, all pieces were assumed to start with localkey `I` or `i`. Now it is possible to have the global key *and* a change of local key within the first label, e.g. `Ab.vi.i` for a piece in Ab major that begins with an introduction in the relative key.
 * Previously accepted for no apparent reason, leading dots are not allowed for `relativeroot` anymore. For example, this would have been legal before, although never used: `V/.bIII`. The correct version is `V/bIII`.
 * Relative roots of unbouded levels are allowed now, as in `V7/V/V`. The feature `relativeroot` would be extracted as `V/V` in this case, i.e. without the initial slash.
 

--- a/guidelines/english.md
+++ b/guidelines/english.md
@@ -141,7 +141,7 @@ If a symbol relates to a different key than the one you are in, you can indicate
 
 ![relativekey](pics/relativekey.png)
 
-Starting from version *2.1.0* of this standard, relative keys of relative keys can be annotated, for example the dominant of the dominant of the dominant: `V7/V/V`.
+Relative keys of relative keys can be annotated, for example the dominant of the dominant of the dominant: `V7/V/V`.
 
 ## Roman numerals
 

--- a/guidelines/english.md
+++ b/guidelines/english.md
@@ -141,6 +141,8 @@ If a symbol relates to a different key than the one you are in, you can indicate
 
 ![relativekey](pics/relativekey.png)
 
+Starting from version *2.1.0* of this standard, relative keys of relative keys can be annotated, for example the dominant of the dominant of the dominant: `V7/V/V`.
+
 ## Roman numerals
 
 The smallest possible symbols consist of a single Roman numeral. They stand for a major (`I, II, III, IV, V, VI, VII`) or minor (`i, ii, iii, iv, v, vi, vii`) triad in root position. *All other chords* - those which are no major or minor root position triad on one of the key's natural degrees - need additional symbols. For altered scale degrees simply use `[.]b/#`+[Roman numeral], e.g. `.bVI` for an Ab major chord in the context of C major; or `#vi` for an A minor chord in the context of C minor. Remember the leading dots if `b` appears at the beginning of a symbol (`V/bVI` works but `bVI` not!).

--- a/harmony.py
+++ b/harmony.py
@@ -1,7 +1,8 @@
 # Regular expression needs to be compiled using re.compile(regex, re.VERBOSE)
 regex = r"""^
     (\.)?
-    ((?P<key>[a-gA-G](b*|\#*)|(b*|\#*)(VII|VI|V|IV|III|II|I|vii|vi|v|iv|iii|ii|i))\.)?
+    ((?P<globalkey>[a-gA-G](b*|\#*))\.)?
+    ((?P<localkey>(b*|\#*)(VII|VI|V|IV|III|II|I|vii|vi|v|iv|iii|ii|i))\.)?
     ((?P<pedal>(b*|\#*)(VII|VI|V|IV|III|II|I|vii|vi|v|iv|iii|ii|i))\[)?
     (?P<chord>
         (?P<numeral>(b*|\#*)(VII|VI|V|IV|III|II|I|vii|vi|v|iv|iii|ii|i|Ger|It|Fr))

--- a/harmony.py
+++ b/harmony.py
@@ -1,7 +1,6 @@
 # Regular expression needs to be compiled using re.compile(regex, re.VERBOSE)
 regex = r"""^
-    (\.)?
-    ((?P<globalkey>[a-gA-G](b*|\#*))\.)?
+    (\.(?P<globalkey>[a-gA-G](b*|\#*))\.)?
     ((?P<localkey>(b*|\#*)(VII|VI|V|IV|III|II|I|vii|vi|v|iv|iii|ii|i))\.)?
     ((?P<pedal>(b*|\#*)(VII|VI|V|IV|III|II|I|vii|vi|v|iv|iii|ii|i))\[)?
     (?P<chord>

--- a/harmony.py
+++ b/harmony.py
@@ -4,11 +4,12 @@ regex = r"""^
     ((?P<key>[a-gA-G](b*|\#*)|(b*|\#*)(VII|VI|V|IV|III|II|I|vii|vi|v|iv|iii|ii|i))\.)?
     ((?P<pedal>(b*|\#*)(VII|VI|V|IV|III|II|I|vii|vi|v|iv|iii|ii|i))\[)?
     (?P<chord>
-    (?P<numeral>(b*|\#*)(VII|VI|V|IV|III|II|I|vii|vi|v|iv|iii|ii|i|Ger|It|Fr))
-    (?P<form>[%o+M])?
-    (?P<figbass>(7|65|43|42|2|64|6))?
-    (\((?P<changes>(\+?(b*|\#*)\d)+)\))?
-    (/\.?(?P<relativeroot>(b*|\#*)(VII|VI|V|IV|III|II|I|vii|vi|v|iv|iii|ii|i)))?)
+        (?P<numeral>(b*|\#*)(VII|VI|V|IV|III|II|I|vii|vi|v|iv|iii|ii|i|Ger|It|Fr))
+        (?P<form>[%o+M])?
+        (?P<figbass>(7|65|43|42|2|64|6))?
+        (\((?P<changes>(\+?(b*|\#*)\d)+)\))?
+        (/(?P<relativeroot>((b*|\#*)(VII|VI|V|IV|III|II|I|vii|vi|v|iv|iii|ii|i)/?)*))?
+    )
     (?P<pedalend>\])?
     (?P<phraseend>\\\\)?$
     """


### PR DESCRIPTION
Since the replacement of `Ger` includes a `relativeroot`, namely `V`, in cases where it was itself used with a relativeroot, e.g. `Ger6/vi`, need to be dealt with. We are dealing with a doubly relative root, `viio65(b3)/V/vi`. Of course that can be merged to `viio65(b3)/III` at one point but then you lose information; also, for that you need to know the mode of the local key.

Therefore, I suggest to go the opposite way and instead allow doubly relative roots even when annotating. In fact, the request had come up before whether we could have something like `V7/V/V`. Until now, annotators indeed had to merge the keys (`V7/II`). This change cannot be automatically corrected in previous annotations. The regex is downward compatible.